### PR TITLE
Add ability to set SparkPost transmission options

### DIFF
--- a/lib/swoosh/adapters/sparkpost.ex
+++ b/lib/swoosh/adapters/sparkpost.ex
@@ -31,6 +31,21 @@ defmodule Swoosh.Adapters.SparkPost do
         first_name: "Peter",
         last_name: "Parker"
       })
+  
+  ## Setting SparkPost transmission options
+  
+      import Swoosh.Email
+      
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")   
+      |> put_provider_option(:options, %{
+        click_tracking: false,
+        open_tracking: false,
+        transactional: true,
+        inline_css: true
+      })
   """
 
   use Swoosh.Adapter, required_config: [:api_key]
@@ -96,6 +111,7 @@ defmodule Swoosh.Adapters.SparkPost do
     |> prepare_attachments(email)
     |> prepare_template_id(email)
     |> prepare_substitutions(email)
+    |> prepare_options(email)
   end
 
   defp prepare_reply_to(body, %{reply_to: nil}), do: body
@@ -171,6 +187,12 @@ defmodule Swoosh.Adapters.SparkPost do
   end
 
   defp prepare_substitutions(body, _email), do: body
+
+  defp prepare_options(body, %{provider_options: %{options: options}}) do
+    Map.put(body, :options, options)
+  end
+
+  defp prepare_options(body, _email), do: body
 
   defp prepare_custom_headers(body, %{headers: headers}) do
     custom_headers = Map.merge(body.content.headers, headers)


### PR DESCRIPTION
This adds the ability to set `options` as defined in the SparkPost transmission API documentation:

https://developers.sparkpost.com/api/transmissions/#header-request-body

Note that the `options` set are simply passed as-is in the JSON body sent to SparkPost, to use with care.